### PR TITLE
feat(issue):sparkles:: Automation of work progress label on pull requests and reaction to commands

### DIFF
--- a/automation/addLabelsOnPullRequest.automation.js
+++ b/automation/addLabelsOnPullRequest.automation.js
@@ -74,3 +74,68 @@ exports.addMergedLabel = async context => {
 		}
 	}
 };
+
+exports.pullRequestWIPLabelAutomation = async context => {
+	const { title } = context.payload.pull_request;
+
+	const issueLabels = await listIssueLabels(context);
+	const foundWIPLabel = issueLabels.data.filter(
+		label => label.name === ':construction: WIP'
+	);
+	const foundReadyForReviewLabel = issueLabels.data.filter(
+		label => label.name === ':mag: Ready For Review'
+	);
+
+	if (
+		(title.includes('WIP') ||
+			title.includes('Work In Progress') ||
+			title.includes('work in progress') ||
+			title.includes(':construction:')) &&
+		foundWIPLabel.length === 0
+	) {
+		addLabel([':construction: WIP'], context);
+
+		if (foundReadyForReviewLabel.length === 0) {
+			removeLabel([':mag: Ready For Review'], context);
+		}
+
+		return;
+	}
+
+	if (
+		foundWIPLabel.length > 0 &&
+		!title.includes('WIP') &&
+		!title.includes('Work In Progress') &&
+		!title.includes('work in progress') &&
+		!title.includes(':construction:')
+	) {
+		removeLabel([':construction: WIP'], context);
+
+		if (foundReadyForReviewLabel.length === 0) {
+			addLabel([':mag: Ready For Review'], context);
+		}
+
+		return;
+	}
+
+	if (
+		title.includes('WIP') ||
+		title.includes('Work In Progress') ||
+		title.includes('work in progress') ||
+		title.includes(':construction:')
+	) {
+		if (foundWIPLabel.length === 0) {
+			addLabel([':construction: WIP'], context);
+		}
+
+		if (foundReadyForReviewLabel.length > 0) {
+			removeLabel([':mag: Ready For Review'], context);
+		}
+
+		return;
+	}
+
+	if (foundReadyForReviewLabel.length > 0 && foundWIPLabel.length > 0) {
+		return removeLabel([':mag: Ready For Review'], context);
+	}
+};

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const {
 	addReadyForReviewLabel,
 	addApprovedLabel,
 	addMergedLabel,
+	pullRequestWIPLabelAutomation,
 } = require('./automation/addLabelsOnPullRequest.automation');
 const addLabelToIssueOnClose = require('./automation/addLabelToIssueOnClose.automation');
 const approveCommand = require('./commands/approve.command');
@@ -11,7 +12,8 @@ const mergeCommand = require('./commands/merge.command');
 const WIPCommand = require('./commands/wip.command');
 const { createComment, deleteComment } = require('./helpers/comment.helper');
 const getCommandAndArgs = require('./helpers/getCommandAndArgs.helper');
-const { addLabel } = require('./helpers/label.helper');
+const { addLabel, removeLabel } = require('./helpers/label.helper');
+const { listIssueLabels } = require('./helpers/listLabels.helper');
 
 const availableCommandsMessage = `Available commands are:- 
 						    - **/label** - Add labels to an issue or pull request.
@@ -29,6 +31,12 @@ module.exports = app => {
 	app.on('pull_request.opened', addReadyForReviewLabel);
 	app.on('pull_request_review', addApprovedLabel);
 	app.on('pull_request.closed', addMergedLabel);
+
+	app.on(
+		['pull_request.edited', 'pull_request.labeled'],
+		pullRequestWIPLabelAutomation
+	);
+
 	app.on('issues.closed', addLabelToIssueOnClose);
 
 	/* --------------------------------- ANCHOR Issue commands --------------------------------- */

--- a/index.js
+++ b/index.js
@@ -43,6 +43,16 @@ module.exports = app => {
 	app.on('issue_comment.created', async context => {
 		const { body } = context.payload.comment;
 		const { command, args } = getCommandAndArgs(body);
+		const commentId = context.payload.comment.id;
+
+		if (command[0] === '/' && !context.isBot) {
+			const params = context.issue({
+				comment_id: commentId,
+				content: '+1',
+			});
+
+			context.octokit.reactions.createForIssueComment(params);
+		}
 
 		switch (command) {
 			case '/label':
@@ -64,6 +74,13 @@ module.exports = app => {
 			default:
 				if (command[0] === '/') {
 					if (!context.isBot) {
+						const params = context.issue({
+							comment_id: commentId,
+							content: '-1',
+						});
+
+						context.octokit.reactions.createForIssueComment(params);
+
 						createComment(
 							context,
 							`**${command}** command doesn't exist.


### PR DESCRIPTION
# Description

- when user adds WIP label than Ready for Review label will be removed
- when user added WIP in title WIP label will be added and vice versa
- Bot will react to all comment commands with thumb up emoji

Fixes #2 #3 #4 

# Checklist:

-   [ x ] I have performed a self-review of my own code
-   [ x ] I have commented my code, particularly in hard-to-understand areas
