### PR TITLE
feat(pull_reqeust): :sparkles: When pull request is closed add `closed` label and remove `ready for review` or `approved` label

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@
 ## Features
 
 - Automatically add labels to pull requests eg:- `Approved`, `Merged`
-- Automatically add `WIP` label when title contains any of these keywords `WIP`, `Work In Progress`, `work in progress`, `🚧`
-- If `WIP` label is added by user than add `🚧` prefix to issue/pull_request title
 - `/` commands can be used in comments eg:- `/approve`, `/merge`, `/label documentation`
-- Bot will react with `👍` emoji when a command is found in comment
+- Bot will react with `:rocket:` emoji when a command is found in comment
 
 ## Demo
 
@@ -32,14 +30,6 @@
 - Merged (pull_request)
 
   ![Merged](https://user-images.githubusercontent.com/69336518/185300751-c0d47387-c2f3-400b-b6db-6637caa3e328.gif)
-
-- When title contains `WIP`, `Work In Progress`, `:construction:` than add `WIP` Label (pull_request, issue (future release))
-
-  ![Add WIP label when title is updated](https://user-images.githubusercontent.com/69336518/185333109-255911da-3f37-485a-ba7c-03b6af58ef75.gif)
-
-- When title is edited and `WIP` is removed from title than label will also be removed (pull_request, issue(future release))
-
-  ![Auto remove WIP label](https://user-images.githubusercontent.com/69336518/185333772-258192b8-6974-4a0c-8d05-7aa594f0067e.gif)
 
 ### `/` command
 
@@ -72,7 +62,7 @@
 - `/close` (pull_request, issue)
 
   ![Close command](https://user-images.githubusercontent.com/69336518/185327801-89852c28-8ec7-4a70-bde6-8025a4afe0a2.gif)
-  
+
 ## Contributing
 
 If you have suggestions for how shriproperty could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/automation/addLabelToIssueOnClose.automation.js
+++ b/automation/addLabelToIssueOnClose.automation.js
@@ -1,21 +1,21 @@
-const { addLabel } = require('../helpers/label.helper');
-const { listIssueLabels } = require('../helpers/listLabels.helper');
+const { addLabel } = require("../helpers/label.helper");
+const { listIssueLabels } = require("../helpers/listLabels.helper");
 
 const addLabelToIssueOnClose = async context => {
 	const issueLabels = await listIssueLabels(context);
 
-	const previousBugLabel = issueLabels.data.find(label => label.name === 'bug');
+	const previousBugLabel = issueLabels.data.find(label => label.name === "bug");
 
 	const previousFeatureLabel = issueLabels.data.find(
-		label => label.name === 'feature' || label.name === 'enhancement'
+		label => label.name === "feature" || label.name === "enhancement"
 	);
 
 	if (previousBugLabel) {
-		addLabel(['fixed'], context);
+		addLabel(["fixed"], context);
 	}
 
 	if (previousFeatureLabel) {
-		addLabel(['implemented'], context);
+		addLabel(["implemented"], context);
 	}
 };
 

--- a/automation/addLabelsOnPullRequest.automation.js
+++ b/automation/addLabelsOnPullRequest.automation.js
@@ -139,3 +139,38 @@ exports.changesRequestLabel = async context => {
 		removeLabel([":white_check_mark: Approved"], context);
 	}
 };
+
+exports.addCloseLabel = async context => {
+	const params = context.pullRequest();
+
+	try {
+		const pullRequestIsMerged = await context.octokit.pulls.checkIfMerged(
+			params
+		);
+	} catch (err) {
+		const issueLabels = await listIssueLabels(context);
+		const foundReadyForReviewLabel = issueLabels.data.filter(
+			label => label.name === ":mag: Ready for Review"
+		);
+		const foundApprovedLabel = issueLabels.data.filter(
+			label => label.name === ":white_check_mark: Approved"
+		);
+		const foundChangesRequestedLabel = issueLabels.data.filter(
+			label => label.name === ":warning: Changes requested"
+		);
+
+		if (foundReadyForReviewLabel.length > 0) {
+			removeLabel([":mag: Ready for Review"], context);
+		}
+
+		if (foundApprovedLabel.length > 0) {
+			removeLabel([":white_check_mark: Approved"], context);
+		}
+
+		if (foundChangesRequestedLabel.length > 0) {
+			removeLabel([":warning: Changes requested"], context);
+		}
+
+		addLabel([":x: closed"], context, "B60205");
+	}
+};

--- a/automation/addLabelsOnPullRequest.automation.js
+++ b/automation/addLabelsOnPullRequest.automation.js
@@ -39,6 +39,10 @@ exports.addApprovedLabel = async context => {
 		removeLabel([":warning: Changes requested"], context);
 	}
 
+	if (approvedReviews.length === 0 && approvedLabel.length > 0) {
+		removeLabel([":white_check_mark: Approved"], context);
+	}
+
 	if (approvedReviews.length > 0) {
 		const issueLabels = await listIssueLabels(context);
 
@@ -78,7 +82,6 @@ exports.addMergedLabel = async context => {
 		if (foundWIPLabel.length > 0) {
 			removeLabel([":construction: WIP"], context);
 		}
-		console.log(title);
 
 		if (
 			title.includes("WIP") ||

--- a/automation/addLabelsOnPullRequest.automation.js
+++ b/automation/addLabelsOnPullRequest.automation.js
@@ -2,14 +2,14 @@ const {
 	createLabel,
 	addLabel,
 	removeLabel,
-} = require('../helpers/label.helper');
+} = require("../helpers/label.helper");
 const {
 	listRepoLabels,
 	listIssueLabels,
-} = require('../helpers/listLabels.helper');
+} = require("../helpers/listLabels.helper");
 
 exports.addReadyForReviewLabel = async context => {
-	addLabel([':mag: Ready for Review'], context);
+	addLabel([":mag: Ready for Review"], context);
 };
 
 exports.addApprovedLabel = async context => {
@@ -18,42 +18,40 @@ exports.addApprovedLabel = async context => {
 
 	const reviews = await context.octokit.pulls.listReviews(params);
 	const approvedLabel = issueLabels.data.filter(
-		label => label.name === ':white_check_mark: Approved'
+		label => label.name === ":white_check_mark: Approved"
 	);
 	const changesRequestedLabel = issueLabels.data.filter(
-		label => label.name === ':warning: Changes requested'
+		label => label.name === ":warning: Changes requested"
 	);
 
 	const approvedReviews = reviews.data.filter(
-		review => review.state === 'APPROVED'
+		review => review.state === "APPROVED"
 	);
 
 	const foundChangesRequestedReview = issueLabels.data.filter(
-		review => review.state === 'CHANGES_REQUESTED'
+		review => review.state === "CHANGES_REQUESTED"
 	);
 
 	if (
 		foundChangesRequestedReview.length === 0 &&
 		changesRequestedLabel.length > 0
 	) {
-		removeLabel([':warning: Changes requested'], context);
-	}
-
-	if (approvedReviews.length === 0 && approvedLabel.length > 0) {
-		removeLabel([':white_check_mark: Approved'], context);
+		removeLabel([":warning: Changes requested"], context);
 	}
 
 	if (approvedReviews.length > 0) {
 		const issueLabels = await listIssueLabels(context);
 
 		const foundReviewLabel = issueLabels.data.filter(
-			label => label.name === ':mag: Ready for Review'
+			label => label.name === ":mag: Ready for Review"
 		);
 
-		addLabel([':white_check_mark: Approved'], context);
+		if (approvedLabel.length === 0) {
+			addLabel([":white_check_mark: Approved"], context);
+		}
 
 		if (foundReviewLabel.length > 0) {
-			removeLabel([':mag: Ready for Review'], context);
+			removeLabel([":mag: Ready for Review"], context);
 		}
 	}
 };
@@ -65,100 +63,35 @@ exports.addMergedLabel = async context => {
 		const issueLabels = await listIssueLabels(context);
 
 		const foundApproveLabel = issueLabels.data.filter(
-			label => label.name === ':white_check_mark: Approved'
+			label => label.name === ":white_check_mark: Approved"
 		);
 		const foundWIPLabel = issueLabels.data.filter(
-			label => label.name === ':construction: WIP'
+			label => label.name === ":construction: WIP"
 		);
 
-		addLabel([':sparkles: Merged:'], context);
+		addLabel([":sparkles: Merged:"], context);
 
 		if (foundApproveLabel.length > 0) {
-			removeLabel([':white_check_mark: Approved'], context);
+			removeLabel([":white_check_mark: Approved"], context);
 		}
 
 		if (foundWIPLabel.length > 0) {
-			removeLabel([':construction: WIP'], context);
+			removeLabel([":construction: WIP"], context);
 		}
 		console.log(title);
 
 		if (
-			title.includes('WIP') ||
-			title.includes('Work In Progress') ||
-			title.includes('work in progress') ||
-			title.includes(':construction:')
+			title.includes("WIP") ||
+			title.includes("Work In Progress") ||
+			title.includes("work in progress") ||
+			title.includes(":construction:")
 		) {
 			const params = context.pullRequest({
-				title: `${title.replace(':construction:', '')}`,
+				title: `${title.replace(":construction:", "")}`,
 			});
 
 			context.octokit.pulls.update(params);
 		}
-	}
-};
-
-exports.pullRequestWIPLabelAutomation = async context => {
-	const { title } = context.payload.pull_request;
-
-	const issueLabels = await listIssueLabels(context);
-	const foundWIPLabel = issueLabels.data.filter(
-		label => label.name === ':construction: WIP'
-	);
-	const foundReadyForReviewLabel = issueLabels.data.filter(
-		label => label.name === ':mag: Ready for Review'
-	);
-
-	if (
-		(title.includes('WIP') ||
-			title.includes('Work In Progress') ||
-			title.includes('work in progress') ||
-			title.includes(':construction:')) &&
-		foundWIPLabel.length === 0
-	) {
-		addLabel([':construction: WIP'], context);
-
-		if (foundReadyForReviewLabel.length === 0) {
-			removeLabel([':mag: Ready for Review'], context);
-		}
-
-		return;
-	}
-
-	if (
-		foundWIPLabel.length > 0 &&
-		!title.includes('WIP') &&
-		!title.includes('Work In Progress') &&
-		!title.includes('work in progress') &&
-		!title.includes(':construction:')
-	) {
-		removeLabel([':construction: WIP'], context);
-
-		if (foundReadyForReviewLabel.length === 0) {
-			addLabel([':mag: Ready for Review'], context);
-		}
-
-		return;
-	}
-
-	if (
-		title.includes('WIP') ||
-		title.includes('Work In Progress') ||
-		title.includes('work in progress') ||
-		title.includes(':construction:')
-	) {
-		if (foundWIPLabel.length === 0) {
-			addLabel([':construction: WIP'], context);
-		}
-
-		if (foundReadyForReviewLabel.length > 0) {
-			removeLabel([':mag: Ready for Review'], context);
-		}
-
-		return;
-	}
-
-	if (foundReadyForReviewLabel.length > 0 && foundWIPLabel.length > 0) {
-		return removeLabel([':mag: Ready for Review'], context);
 	}
 };
 
@@ -170,36 +103,36 @@ exports.changesRequestLabel = async context => {
 	const reviews = await context.octokit.pulls.listReviews(params);
 
 	const changesRequestedReviews = reviews.data.filter(
-		review => review.state === 'CHANGES_REQUESTED'
+		review => review.state === "CHANGES_REQUESTED"
 	);
 
 	const foundChangedRequestedLabel = issueLabels.data.filter(
-		label => label.name === ':warning: Changes requested'
+		label => label.name === ":warning: Changes requested"
 	);
 
 	const foundReadyForReviewLabel = issueLabels.data.filter(
-		label => label.name === ':mag: Ready for Review'
+		label => label.name === ":mag: Ready for Review"
 	);
 
 	const foundApprovedLabel = issueLabels.data.filter(
-		label => label.name === ':white_check_mark: Approved'
+		label => label.name === ":white_check_mark: Approved"
 	);
 
 	if (
 		changesRequestedReviews.length > 0 &&
 		foundChangedRequestedLabel.length === 0
 	) {
-		addLabel([':warning: Changes requested'], context, 'AA2626');
+		addLabel([":warning: Changes requested"], context, "AA2626");
 	}
 
 	if (
 		changesRequestedReviews.length > 0 &&
 		foundReadyForReviewLabel.length > 0
 	) {
-		removeLabel([':mag: Ready for Review'], context);
+		removeLabel([":mag: Ready for Review"], context);
 	}
 
 	if (changesRequestedReviews.length > 0 && foundApprovedLabel.length > 0) {
-		removeLabel([':white_check_mark: Approved'], context);
+		removeLabel([":white_check_mark: Approved"], context);
 	}
 };

--- a/commands/wip.command.js
+++ b/commands/wip.command.js
@@ -1,37 +1,58 @@
-const { addLabel, removeLabel } = require('../helpers/label.helper');
-const { listIssueLabels } = require('../helpers/listLabels.helper');
+const { addLabel, removeLabel } = require("../helpers/label.helper");
+const { listIssueLabels } = require("../helpers/listLabels.helper");
 
 const WIPCommand = async context => {
 	const { title } = context.payload.issue || context.payload.pull_request;
 	const labelsFromIssues = await listIssueLabels(context);
 
 	const wipLabel = labelsFromIssues.data.find(
-		label => label.name === ':construction: WIP'
+		label => label.name === ":construction: WIP"
+	);
+	const foundReadyForReviewLabel = labelsFromIssues.data.find(
+		label => label.name === ":mag: Ready for Review"
 	);
 
 	if (
-		title.includes('WIP') ||
-		title.includes('Work In Progress') ||
-		title.includes('work in progress') ||
-		title.includes(':construction:')
+		title.includes("WIP") ||
+		title.includes("Work In Progress") ||
+		title.includes("work in progress") ||
+		title.includes(":construction:")
 	) {
 		const params = context.issue({
-			title: `${context.payload.issue.title.replace(':construction:', '')}`,
+			title: `${context.payload.issue.title.replace(":construction:", "")}`,
 		});
 
 		context.octokit.issues.update(params);
 	}
 
 	if (wipLabel) {
-		return removeLabel(':construction: WIP', context);
+		if (!foundReadyForReviewLabel) {
+			addLabel([":mag: Ready for Review"], context);
+		}
+
+		return removeLabel(":construction: WIP", context);
 	}
 
-	addLabel([':construction: WIP'], context, '383214');
-	const params = context.issue({
-		title: `:construction: ${context.payload.issue.title}`,
-	});
+	if (!wipLabel) {
+		if (foundReadyForReviewLabel) {
+			removeLabel(":mag: Ready for Review", context);
+		}
 
-	context.octokit.issues.update(params);
+		addLabel([":construction: WIP"], context, "383214");
+	}
+
+	if (
+		!title.includes("WIP") ||
+		!title.includes("Work In Progress") ||
+		!title.includes("work in progress") ||
+		!title.includes(":construction:")
+	) {
+		const params = context.issue({
+			title: `:construction: ${context.payload.issue.title}`,
+		});
+
+		context.octokit.issues.update(params);
+	}
 };
 
 module.exports = WIPCommand;

--- a/index.js
+++ b/index.js
@@ -34,7 +34,48 @@ module.exports = app => {
 
 	app.on("pull_request_review.submitted", addApprovedLabel);
 	app.on("pull_request_review.submitted", changesRequestLabel);
+
 	app.on("pull_request.closed", addMergedLabel);
+	app.on("pull_request.closed", async context => {
+		const params = context.pullRequest();
+
+		try {
+			const pullRequestIsMerged = await context.octokit.pulls.checkIfMerged(
+				params
+			);
+		} catch (err) {
+			const issueLabels = await listIssueLabels(context);
+			const foundReadyForReviewLabel = issueLabels.data.filter(
+				label => label.name === ":mag: Ready for Review"
+			);
+			const foundApprovedLabel = issueLabels.data.filter(
+				label => label.name === ":white_check_mark: Approved"
+			);
+			const foundChangesRequestedLabel = issueLabels.data.filter(
+				label => label.name === ":warning: Changes requested"
+			);
+
+			if (foundReadyForReviewLabel.length > 0) {
+				removeLabel([":mag: Ready for Review"], context);
+			}
+
+			if (foundApprovedLabel.length > 0) {
+				removeLabel([":white_check_mark: Approved"], context);
+			}
+
+			if (foundChangesRequestedLabel.length > 0) {
+				removeLabel([":warning: Changes requested"], context);
+			}
+
+			addLabel([":x: closed"], context, "B60205");
+		}
+	});
+
+	app.on(
+		["pull_request.edited", "pull_request.labeled"],
+		pullRequestWIPLabelAutomation
+	);
+
 	app.on("issues.closed", addLabelToIssueOnClose);
 
 	/* --------------------------------- ANCHOR Issue commands --------------------------------- */

--- a/index.js
+++ b/index.js
@@ -2,19 +2,20 @@ const {
 	addReadyForReviewLabel,
 	addApprovedLabel,
 	addMergedLabel,
-	pullRequestWIPLabelAutomation,
+	WIPLabelAutomation: pullRequestWIPLabelAutomation,
 	changesRequestLabel,
-} = require('./automation/addLabelsOnPullRequest.automation');
-const addLabelToIssueOnClose = require('./automation/addLabelToIssueOnClose.automation');
-const approveCommand = require('./commands/approve.command');
-const closeCommand = require('./commands/close.command');
-const labelCommand = require('./commands/label.command');
-const mergeCommand = require('./commands/merge.command');
-const WIPCommand = require('./commands/wip.command');
-const { createComment, deleteComment } = require('./helpers/comment.helper');
-const getCommandAndArgs = require('./helpers/getCommandAndArgs.helper');
-const { addLabel, removeLabel } = require('./helpers/label.helper');
-const { listIssueLabels } = require('./helpers/listLabels.helper');
+	removeWIPLabel,
+} = require("./automation/addLabelsOnPullRequest.automation");
+const addLabelToIssueOnClose = require("./automation/addLabelToIssueOnClose.automation");
+const approveCommand = require("./commands/approve.command");
+const closeCommand = require("./commands/close.command");
+const labelCommand = require("./commands/label.command");
+const mergeCommand = require("./commands/merge.command");
+const WIPCommand = require("./commands/wip.command");
+const { createComment, deleteComment } = require("./helpers/comment.helper");
+const getCommandAndArgs = require("./helpers/getCommandAndArgs.helper");
+const { addLabel, removeLabel } = require("./helpers/label.helper");
+const { listIssueLabels } = require("./helpers/listLabels.helper");
 
 const availableCommandsMessage = `Available commands are:- 
 						    - **/label** - Add labels to an issue or pull request.
@@ -29,58 +30,51 @@ const availableCommandsMessage = `Available commands are:-
  */
 module.exports = app => {
 	/* --------------------------------- ANCHOR Automation --------------------------------- */
-	app.on('pull_request.opened', addReadyForReviewLabel);
+	app.on("pull_request.opened", addReadyForReviewLabel);
 
-	app.on('pull_request_review.submitted', addApprovedLabel);
-	app.on('pull_request_review.submitted', changesRequestLabel);
-
-	app.on('pull_request.closed', addMergedLabel);
-
-	app.on(
-		['pull_request.edited', 'pull_request.labeled'],
-		pullRequestWIPLabelAutomation
-	);
-
-	app.on('issues.closed', addLabelToIssueOnClose);
+	app.on("pull_request_review.submitted", addApprovedLabel);
+	app.on("pull_request_review.submitted", changesRequestLabel);
+	app.on("pull_request.closed", addMergedLabel);
+	app.on("issues.closed", addLabelToIssueOnClose);
 
 	/* --------------------------------- ANCHOR Issue commands --------------------------------- */
-	app.on('issue_comment.created', async context => {
+	app.on("issue_comment.created", async context => {
 		const { body } = context.payload.comment;
 		const { command, args } = getCommandAndArgs(body);
 		const commentId = context.payload.comment.id;
 
-		if (command[0] === '/' && !context.isBot) {
+		if (command[0] === "/" && !context.isBot) {
 			const params = context.issue({
 				comment_id: commentId,
-				content: '+1',
+				content: "+1",
 			});
 
 			context.octokit.reactions.createForIssueComment(params);
 		}
 
 		switch (command) {
-			case '/label':
+			case "/label":
 				labelCommand(context, args);
 				break;
-			case '/close':
+			case "/close":
 				closeCommand(context);
 				break;
-			case '/approve':
+			case "/approve":
 				approveCommand(context);
 				break;
-			case '/merge':
+			case "/merge":
 				mergeCommand(context);
 				break;
-			case '/WIP':
+			case "/WIP":
 				WIPCommand(context);
 				break;
 
 			default:
-				if (command[0] === '/') {
+				if (command[0] === "/") {
 					if (!context.isBot) {
 						const params = context.issue({
 							comment_id: commentId,
-							content: '-1',
+							content: "-1",
 						});
 
 						context.octokit.reactions.createForIssueComment(params);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const {
 	addMergedLabel,
 	WIPLabelAutomation: pullRequestWIPLabelAutomation,
 	changesRequestLabel,
-	removeWIPLabel,
+	addCloseLabel,
 } = require("./automation/addLabelsOnPullRequest.automation");
 const addLabelToIssueOnClose = require("./automation/addLabelToIssueOnClose.automation");
 const approveCommand = require("./commands/approve.command");
@@ -36,40 +36,7 @@ module.exports = app => {
 	app.on("pull_request_review.submitted", changesRequestLabel);
 
 	app.on("pull_request.closed", addMergedLabel);
-	app.on("pull_request.closed", async context => {
-		const params = context.pullRequest();
-
-		try {
-			const pullRequestIsMerged = await context.octokit.pulls.checkIfMerged(
-				params
-			);
-		} catch (err) {
-			const issueLabels = await listIssueLabels(context);
-			const foundReadyForReviewLabel = issueLabels.data.filter(
-				label => label.name === ":mag: Ready for Review"
-			);
-			const foundApprovedLabel = issueLabels.data.filter(
-				label => label.name === ":white_check_mark: Approved"
-			);
-			const foundChangesRequestedLabel = issueLabels.data.filter(
-				label => label.name === ":warning: Changes requested"
-			);
-
-			if (foundReadyForReviewLabel.length > 0) {
-				removeLabel([":mag: Ready for Review"], context);
-			}
-
-			if (foundApprovedLabel.length > 0) {
-				removeLabel([":white_check_mark: Approved"], context);
-			}
-
-			if (foundChangesRequestedLabel.length > 0) {
-				removeLabel([":warning: Changes requested"], context);
-			}
-
-			addLabel([":x: closed"], context, "B60205");
-		}
-	});
+	app.on("pull_request.closed", addCloseLabel);
 
 	app.on(
 		["pull_request.edited", "pull_request.labeled"],


### PR DESCRIPTION
# Description

When pull request is closed add `closed` label and remove `ready for review` or `approved` label
Closes #27 

# Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation (postman)

# Screenshots

![image](https://user-images.githubusercontent.com/69336518/187070551-82aa2b32-96ef-4dba-986f-96e48f7a8743.png)

